### PR TITLE
Changed permalink of Swig page

### DIFF
--- a/pages/docs/swig.md
+++ b/pages/docs/swig.md
@@ -1,6 +1,6 @@
 ---
 title: Swig
-permalink: /Swig
+permalink: /swig
 sidebar: docs_sidebar
 folder: docs
 ---


### PR DESCRIPTION
Currently the Sidebar's Swig link is linking to /swig rather than /Swig