### PR TITLE
Update list of dependencies for Ubuntu/Debian

### DIFF
--- a/pages/docs/build.md
+++ b/pages/docs/build.md
@@ -18,7 +18,23 @@ Clang++ (with OpenMP support) can be used as an alternative for C++.
 On a Ubuntu/Debian system, following command installs the necessary developer tools to compile and build Soufflé:
 
 ```
-sudo apt-get install cmake bison build-essential clang doxygen flex g++ git libffi-dev libncurses5-dev libsqlite3-dev make mcpp python sqlite zlib1g-dev
+sudo apt install \
+  bison \
+  build-essential \
+  clang \
+  cmake \
+  doxygen \
+  flex \
+  g++ \
+  git \
+  libffi-dev \
+  libncurses5-dev \
+  libsqlite3-dev \
+  make \
+  mcpp \
+  python \
+  sqlite \
+  zlib1g-dev
 ```
 
 Support for C++17 is required, which is supported in gnu c++ 7/clang++ 7 on.


### PR DESCRIPTION
* Break long command over several lines to improve readability (it is still copy-pasteable)
* Use command `apt` over `apt-get`, this is the preferred frontend on Ubuntu and Debian (see https://www.debian.org/doc/manuals/debian-handbook/sect.apt-get.en.html)
* Sort dependencies alphabetically