### PR TITLE
Clean up build instructions

### DIFF
--- a/pages/docs/build.md
+++ b/pages/docs/build.md
@@ -9,13 +9,19 @@ folder: docs
 
 To build and install Soufflé, the following software must be installed:
 
-* cmake (from version 3.15), GNU C++ supporting C++17 and OpenMP (from version 4.8), Bison (from version 3.0.4), Flex, DoxyGen, sqlite3, mcpp
+* cmake (version 3.15 or greater)
+* GNU C++ supporting C++17 and OpenMP (version 4.8 or greater)
+* GNU Bison (version 3.0.4 or greater)
+* Flex
+* DoxyGen
+* sqlite3
+* mcpp
 
 Clang++ (with OpenMP support) can be used as an alternative for C++.
 
 ### Ubuntu/Debian Build
 
-On a Ubuntu/Debian system, following command installs the necessary developer tools to compile and build Soufflé:
+On a Ubuntu/Debian system the following command installs the necessary dependencies to compile and build Soufflé:
 
 ```
 sudo apt install \
@@ -37,9 +43,10 @@ sudo apt install \
   zlib1g-dev
 ```
 
-Support for C++17 is required, which is supported in gnu c++ 7/clang++ 7 on.
+Support for C++17 is required. This support is present in GNU C++ version 7 or greater and Clang++ version 7 or greater.
 
-The Soufflé project follows cmake conventions for configuring, installing and building software. If not familiar, please refer to the [following document](https://cliutils.gitlab.io/modern-cmake/chapters/intro/running.html) for configuring, building, testing, and installing a project with cmake. You can build Soufflé by typing:
+The Soufflé project follows cmake conventions for configuring, installing and building software. If you are not familiar with cmake, please refer to the [following document](https://cliutils.gitlab.io/modern-cmake/chapters/intro/running.html) for configuring, building, testing, and installing a project. You can build Soufflé by typing:
+
 ```
 cd souffle
 cmake -S . -B build
@@ -53,9 +60,10 @@ which will run `cmake` with 8 jobs at a time.
 
 ### MAC OS X Build
 
-MAC OS X does not have OpenMP/C++ nor a bison version 3.0.2 or higher installed by default. OpenMP is not required, but does improve runtime for large programs by parallelising the execution. 
+MAC OS X does not have OpenMP/C++ nor GNU Bison version 3.0.2 or higher installed by default. OpenMP is not required to build Soufflé, but does improve runtime for large Datalog programs by parallelising the execution.
 
 We recommend [brew](http://brew.sh) to install the required tools for building Soufflé. Run the following commands prior to executing `cmake`:
+
 ```
 brew update
 brew install cmake bison libffi mcpp pkg-config
@@ -94,9 +102,10 @@ ctest -j8
 ```
 which will run 8 jobs at a time.
 
-For more control, `-R <regex>` allows you to run tests that matching the regular expression;
+For more control, `-R <regex>` allows you to run tests that matches the regular expression;
 `-L <regex>` allows you to run tests with _labels_ matching the regular expression, use `--print-labels` to show all available labels;
 `--rerun-failed` allows you to run only the tests that failed previously.
+
 For more options please type `ctest --help`.
 
 ### Installing Soufflé
@@ -116,7 +125,9 @@ the Soufflé commands ```souffle``` and ```souffle-profile``` are available to t
 
 ### Configuring Soufflé
 
-To specify building options, run `cmake -S . -B build -D<option>=<value>`. See below some of the options:
+To specify build options, run `cmake -S . -B build -D<option>=<value>`. Alternatively, run `ccmake build` to start cmake with a terminal GUI interface that lets you configure the options.
+
+The most relevant options are listed below.
 
  - `SOUFFLE_DOMAIN_64BIT` Enable(=`ON`)/disable(=`OFF`) 64-bit number values in Datalog tuples; default is `OFF`, i.e., domain size is 32 bit.
  - `SOUFFLE_SANITISE_MEMORY` Enable(=`ON`)/disable(=`OFF`) memory sanitiser; default is `OFF`.
@@ -128,7 +139,7 @@ To specify building options, run `cmake -S . -B build -D<option>=<value>`. See b
  - `SOUFFLE_USE_ZLIB` Enable(=`ON`)/disable(=`OFF`) use of libz file compression in I/O directives (i.e. `.input`/`.output`); default is `ON`.
  - `SOUFFLE_USE_SQLITE` Enable(=`ON`)/disable use of sqlite3 in I/O directives (i.e. `.input`/`.output`);  default is `ON`. 
 
-The avaiable options are documented in `souffle/CMakeLists.txt`. Alternatively, run `ccmake build` that invokes cmake with a GUI interface and configure the options there.
+All available options can be found by browsing the source code, see `souffle/CMakeLists.txt`.
 
 ## IDE/Editor
 With CMake, you can easily integrate the Souffle project with your IDE/editor.


### PR DESCRIPTION
* Split long line of technologies into list
* Rephrase some sentences and fix some spelling mistakes
* Move tip about `ccmake` to the top of the config section