### PR TITLE
Add documentation for no_magic and no_inline relation qualifiers

### DIFF
--- a/img/relation_decl.svg
+++ b/img/relation_decl.svg
@@ -1,4 +1,4 @@
-<svg xmlns="http://www.w3.org/2000/svg" width="725" height="291">
+<svg xmlns="http://www.w3.org/2000/svg" width="735" height="379">
          <defs>
             <style type="text/css">
     @namespace "http://www.w3.org/2000/svg";
@@ -28,36 +28,42 @@
     polygon.regexp        {fill: #FFF4C7; stroke: #332900; stroke-width: 1;}
   </style>
          </defs>
-         <polygon points="9 271 1 267 1 275"/>
-         <polygon points="17 271 9 267 9 275"/>
-         <rect x="31" y="257" width="52" height="32" rx="10"/>
-         <rect x="29" y="255" width="52" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="39" y="275">.decl</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IDENT" xlink:title="IDENT">
-            <rect x="123" y="257" width="58" height="32"/>
-            <rect x="121" y="255" width="58" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="131" y="275">IDENT</text></a><rect x="123" y="213" width="24" height="32" rx="10"/>
-         <rect x="121" y="211" width="24" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="131" y="231">,</text>
-         <rect x="221" y="257" width="26" height="32" rx="10"/>
-         <rect x="219" y="255" width="26" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="229" y="275">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#attribute" xlink:title="attribute">
-            <rect x="287" y="257" width="74" height="32"/>
-            <rect x="285" y="255" width="74" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="295" y="275">attribute</text></a><rect x="287" y="213" width="24" height="32" rx="10"/>
-         <rect x="285" y="211" width="24" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="295" y="231">,</text>
-         <rect x="401" y="257" width="26" height="32" rx="10"/>
-         <rect x="399" y="255" width="26" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="409" y="275">)</text>
-         <rect x="467" y="223" width="76" height="32" rx="10"/>
-         <rect x="465" y="221" width="76" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="475" y="241">override</text>
-         <rect x="467" y="179" width="56" height="32" rx="10"/>
-         <rect x="465" y="177" width="56" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="475" y="197">inline</text>
-         <rect x="467" y="135" width="60" height="32" rx="10"/>
-         <rect x="465" y="133" width="60" height="32" class="terminal" rx="10"/>
-         <text class="terminal" x="475" y="153">magic</text>
+         <polygon points="9 359 1 355 1 363"/>
+         <polygon points="17 359 9 355 9 363"/>
+         <rect x="31" y="345" width="52" height="32" rx="10"/>
+         <rect x="29" y="343" width="52" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="39" y="363">.decl</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#IDENT" xlink:title="IDENT">
+            <rect x="123" y="345" width="58" height="32"/>
+            <rect x="121" y="343" width="58" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="131" y="363">IDENT</text></a><rect x="123" y="301" width="24" height="32" rx="10"/>
+         <rect x="121" y="299" width="24" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="131" y="319">,</text>
+         <rect x="221" y="345" width="26" height="32" rx="10"/>
+         <rect x="219" y="343" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="229" y="363">(</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#attribute" xlink:title="attribute">
+            <rect x="287" y="345" width="74" height="32"/>
+            <rect x="285" y="343" width="74" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="295" y="363">attribute</text></a><rect x="287" y="301" width="24" height="32" rx="10"/>
+         <rect x="285" y="299" width="24" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="295" y="319">,</text>
+         <rect x="401" y="345" width="26" height="32" rx="10"/>
+         <rect x="399" y="343" width="26" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="409" y="363">)</text>
+         <rect x="467" y="311" width="76" height="32" rx="10"/>
+         <rect x="465" y="309" width="76" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="475" y="329">override</text>
+         <rect x="467" y="267" width="56" height="32" rx="10"/>
+         <rect x="465" y="265" width="56" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="475" y="285">inline</text>
+         <rect x="467" y="223" width="82" height="32" rx="10"/>
+         <rect x="465" y="221" width="82" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="475" y="241">no_inline</text>
+         <rect x="467" y="179" width="60" height="32" rx="10"/>
+         <rect x="465" y="177" width="60" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="475" y="197">magic</text>
+         <rect x="467" y="135" width="86" height="32" rx="10"/>
+         <rect x="465" y="133" width="86" height="32" class="terminal" rx="10"/>
+         <text class="terminal" x="475" y="153">no_magic</text>
          <rect x="467" y="91" width="46" height="32" rx="10"/>
          <rect x="465" y="89" width="46" height="32" class="terminal" rx="10"/>
          <text class="terminal" x="475" y="109">brie</text>
@@ -67,8 +73,8 @@
          <rect x="467" y="3" width="54" height="32" rx="10"/>
          <rect x="465" y="1" width="54" height="32" class="terminal" rx="10"/>
          <text class="terminal" x="475" y="21">eqrel</text><a xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="#choice_domain" xlink:title="choice_domain">
-            <rect x="583" y="257" width="114" height="32"/>
-            <rect x="581" y="255" width="114" height="32" class="nonterminal"/>
-            <text class="nonterminal" x="591" y="275">choice_domain</text></a><svg:path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 271 h2 m0 0 h10 m52 0 h10 m20 0 h10 m58 0 h10 m-98 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m78 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-78 0 h10 m24 0 h10 m0 0 h34 m20 44 h10 m26 0 h10 m20 0 h10 m74 0 h10 m-114 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m94 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-94 0 h10 m24 0 h10 m0 0 h50 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h86 m-116 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m96 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-96 0 h10 m76 0 h10 m-106 10 l0 -44 q0 -10 10 -10 m106 54 l0 -44 q0 -10 -10 -10 m-96 0 h10 m56 0 h10 m0 0 h20 m-106 10 l0 -44 q0 -10 10 -10 m106 54 l0 -44 q0 -10 -10 -10 m-96 0 h10 m60 0 h10 m0 0 h16 m-106 10 l0 -44 q0 -10 10 -10 m106 54 l0 -44 q0 -10 -10 -10 m-96 0 h10 m46 0 h10 m0 0 h30 m-106 10 l0 -44 q0 -10 10 -10 m106 54 l0 -44 q0 -10 -10 -10 m-96 0 h10 m56 0 h10 m0 0 h20 m-106 10 l0 -44 q0 -10 10 -10 m106 54 l0 -44 q0 -10 -10 -10 m-96 0 h10 m54 0 h10 m0 0 h22 m20 254 h10 m114 0 h10 m3 0 h-3"/>
-         <polygon points="715 271 723 267 723 275"/>
-         <polygon points="715 271 707 267 707 275"/></svg>
+            <rect x="593" y="345" width="114" height="32"/>
+            <rect x="591" y="343" width="114" height="32" class="nonterminal"/>
+            <text class="nonterminal" x="601" y="363">choice_domain</text></a><path xmlns:svg="http://www.w3.org/2000/svg" class="line" d="m17 359 h2 m0 0 h10 m52 0 h10 m20 0 h10 m58 0 h10 m-98 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m78 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-78 0 h10 m24 0 h10 m0 0 h34 m20 44 h10 m26 0 h10 m20 0 h10 m74 0 h10 m-114 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -24 q0 -10 10 -10 m94 44 l20 0 m-20 0 q10 0 10 -10 l0 -24 q0 -10 -10 -10 m-94 0 h10 m24 0 h10 m0 0 h50 m20 44 h10 m26 0 h10 m20 0 h10 m0 0 h96 m-126 0 l20 0 m-1 0 q-9 0 -9 -10 l0 -14 q0 -10 10 -10 m106 34 l20 0 m-20 0 q10 0 10 -10 l0 -14 q0 -10 -10 -10 m-106 0 h10 m76 0 h10 m0 0 h10 m-116 10 l0 -44 q0 -10 10 -10 m116 54 l0 -44 q0 -10 -10 -10 m-106 0 h10 m56 0 h10 m0 0 h30 m-116 10 l0 -44 q0 -10 10 -10 m116 54 l0 -44 q0 -10 -10 -10 m-106 0 h10 m82 0 h10 m0 0 h4 m-116 10 l0 -44 q0 -10 10 -10 m116 54 l0 -44 q0 -10 -10 -10 m-106 0 h10 m60 0 h10 m0 0 h26 m-116 10 l0 -44 q0 -10 10 -10 m116 54 l0 -44 q0 -10 -10 -10 m-106 0 h10 m86 0 h10 m-116 10 l0 -44 q0 -10 10 -10 m116 54 l0 -44 q0 -10 -10 -10 m-106 0 h10 m46 0 h10 m0 0 h40 m-116 10 l0 -44 q0 -10 10 -10 m116 54 l0 -44 q0 -10 -10 -10 m-106 0 h10 m56 0 h10 m0 0 h30 m-116 10 l0 -44 q0 -10 10 -10 m116 54 l0 -44 q0 -10 -10 -10 m-106 0 h10 m54 0 h10 m0 0 h32 m20 342 h10 m114 0 h10 m3 0 h-3"/>
+         <polygon points="725 359 733 355 733 363"/>
+         <polygon points="725 359 717 355 717 363"/></svg>

--- a/pages/docs/magicset.md
+++ b/pages/docs/magicset.md
@@ -38,6 +38,8 @@ Magic set can also be enabled within the program using pragma directives:
 
 The complete magic set transformation process can be observed by generating the debug report when the `magic-transform` option is enabled.
 
+The option `magic-transform-exclude` can be used in the same way to disable magic set transformation changes on the given relations. Note that this option also implies `inline-exclude` for the specified relations.
+
 ## The Algorithm
 The algorithm used was based on the work presented in [this paper](http://www.sciencedirect.com/science/article/pii/074310669190030S). The paper details an algorithm for positive datalog programs, and a second for normal programs (containing negations). Only the algorithm for positive datalog has been implemented in the Souffl&eacute; compiler at this point. Relations with negations in their body or the body of a dependency will not be transformed.
 

--- a/pages/docs/relations.md
+++ b/pages/docs/relations.md
@@ -88,7 +88,7 @@ as a boolean variable.  Semantically, they can be seen as a proposition rather t
 In Soufflé, the default data structure is the B-tree, with the *direct* version for relations with arity ≤ 6, or the *indirect* version for relations with arity > 6.
 
 ## Magic-Set Transformation
-The relation qualifier `magic` enables the magic-set transformation for a relation. A magic set transformation specialies the evaluation for a Datalog program for a given set of output relations. The magic-set transformation does not always lead to better performance. Souffle provides the relation qualifier `magic` to control the magic-set transformation. More information can be found [here](magicset).
+The relation qualifier `magic` enables the magic-set transformation for a relation. A magic set transformation specializes the evaluation for a Datalog program for a given set of output relations. The magic-set transformation does not always lead to better performance. Souffle provides the relation qualifier `magic` to enable magic-set transformation and the relation qualifier `no_magic` to disable magic-set transformation (note that `no_magic` also implies `no_inline`). More information on the magic-set transformation can be found [here](magicset).
 
 ## Inlining Relations
 Souffl&eacute; offers the ability to manually select one or more program relations to be inlined, i.e., a substitution of the relations are performed. This may lead to performance gains by re-computing results rather than storing them. For example, 
@@ -182,6 +182,11 @@ Inlining works in all situations, provided the following conditions are met:
     * The restriction is theoretically necessary, as otherwise no ordering for the inlining process can be imposed such that all relations in the cycle are removed.
 * The counter argument, `$`, cannot be used as an argument or in the rule body of an inlined relation.
 * At the moment, relations appearing in aggregators cannot be inlined, though this is only a restriction in practice due to the way certain functors are handled.
+
+### Disable Inlining
+The relation qualifier `no_inline` directs Souffl&eacute; to _not_ inline the marked relation. Note that `no_inline` is implied by the `no_magic` relation qualifier.
+
+The option `inline-exclude` can be used to prevent the given relations from being inlined and overrides any `inline` relation qualifiers. Note that `inline-exclude` is implied by the `magic-transform-exclude` option.
 
 ## Override 
 The relation qualifier `override` controls whether rules in a relation that is defined in a component, can be overwritten in a sub-component. 

--- a/pages/docs/relations.md
+++ b/pages/docs/relations.md
@@ -279,7 +279,7 @@ The definition of attributes is followed by relation qualifiers.
 ![Relation Declaration](https://souffle-lang.github.io/img/relation_decl.svg)
 
 ```ebnf
-relation_decl ::= '.decl' IDENT ( ',' IDENT )* '(' attribute ( ',' attribute )* ')' ( 'override' | 'inline' | 'magic' | 'brie' | 'btree' | 'eqrel' )* choice_domain
+relation_decl ::= '.decl' IDENT ( ',' IDENT )* '(' attribute ( ',' attribute )* ')' ( 'override' | 'inline' | 'no_inline' | 'magic' | 'no_magic' | 'brie' | 'btree' | 'eqrel' )* choice_domain
 ```
 
 ### Choice-Domain


### PR DESCRIPTION
Adds documentation for
* relation qualifiers: `no_magic` and `no_inline`
* options: `inline-exclude` and `magic-transform-exclude`

These relation qualifiers and options were introduced in https://github.com/souffle-lang/souffle/pull/2000 (pending review/merge).