### PR TITLE
Fix typo in the ADT section of types.md

### DIFF
--- a/pages/docs/types.md
+++ b/pages/docs/types.md
@@ -276,7 +276,7 @@ The following example demonstrate how branch constructors can be used in rules:
 
 .decl A(x:Expression)
 A($Number(10)).
-A($Add($Number(10),$Imaginary)).
+A($Add($Number(10),$Imaginary())).
 A($Add($Number(10), $Variable("x"))).
 A($Number(x+1)) :- A($Number(x)), x < 20.
 


### PR DESCRIPTION
Typo in an example has been fixed.