### PR TITLE
refresh the `build` page

### DIFF
--- a/pages/docs/build.md
+++ b/pages/docs/build.md
@@ -10,20 +10,49 @@ folder: docs
 To build and install Soufflé, the following software must be installed:
 
 * cmake (version 3.15 or greater)
-* GNU C++ supporting C++17 and OpenMP (version 4.8 or greater)
+* Python 3
+* A C++ compiler supporting C++17: GNU C++, clang++, Microsoft Visual Studio
+* OpenMP (optional)
 * GNU Bison (version 3.0.4 or greater)
-* Flex
-* DoxyGen
-* sqlite3
-* mcpp
+* flex
+* DoxyGen (optional)
+* git (optional)
+* libffi (optional)
+* libncurses (optional)
+* libsqlite3 (optional)
+* mcpp (optional)
+* swig (optional)
+* zlib (optional)
 
-Clang++ (with OpenMP support) can be used as an alternative for C++.
+## Build
 
-### Ubuntu/Debian Build
+### CMake configuration options
+
+All available options can be found by browsing the source code, see `souffle/CMakeLists.txt`. Below is a table of the most relevant.
+
+To specify build options, run `cmake -S . -B build -D<option>=<value>`. Alternatively, run `ccmake build` to start cmake with a terminal GUI interface that lets you configure the options.
+
+
+| Option | Default | Description
+|--------|---------|------------
+| `CMAKE_BUILD_TYPE`      | `Release` | `Release`, `Debug`
+| `SOUFFLE_DOMAIN_64BIT`  | `OFF`     | Support 64-bit integer and float values in Datalog tuples instead of default's 32-bit
+| `SOUFFLE_SWIG`          | `OFF`     | Support all [`SWIG`](swig) builds
+| `SOUFFLE_SWIG_JAVA`     | `OFF`     | Support Java `SWIG` build
+| `SOUFFLE_SWIG_PYTHON`   | `OFF`     | Support Python `SWIG` build
+| `SOUFFLE_USE_CURSES`    | `ON`      | Support terminal-UI based [provenance](provenance) display
+| `SOUFFLE_USE_LIBFFI`    | `ON`      | Support [c++ functors](interface) with arbitrary number of arguments. When `OFF` limitations applies on the number of arguments in c++ functors supported by the interpreter engine, see `StatelessFunctorMaxArity` and `CALL_STATEFULL` in source code.
+| `SOUFFLE_USE_OPENMP`    | `ON`      | Support parallel evaluation with OpenMP
+| `SOUFFLE_USE_SQLITE`    | `ON`      | Support [sqlite I/Os](directives#iosqlite)
+| `SOUFFLE_USE_ZLIB`      | `ON`      | Support `compress` [file I/Os](directives#iofile)
+| `SOUFFLE_SANITISE_MEMORY` | `OFF`   | Build with memory sanitiser
+| `SOUFFLE_SANITISE_THREAD` | `OFF`   | Build with thread sanitiser
+
+### Ubuntu/Debian Dependencies
 
 On a Ubuntu/Debian system the following command installs the necessary dependencies to compile and build Soufflé:
 
-```
+```sh
 sudo apt install \
   bison \
   build-essential \
@@ -43,17 +72,21 @@ sudo apt install \
   zlib1g-dev
 ```
 
+### Linux Build
+
 Support for C++17 is required. This support is present in GNU C++ version 7 or greater and Clang++ version 7 or greater.
 
-The Soufflé project follows cmake conventions for configuring, installing and building software. If you are not familiar with cmake, please refer to the [following document](https://cliutils.gitlab.io/modern-cmake/chapters/intro/running.html) for configuring, building, testing, and installing a project. You can build Soufflé by typing:
+The Soufflé project follows cmake conventions for configuring, installing and building software. If you are not familiar with cmake, please refer to the [following document](https://cliutils.gitlab.io/modern-cmake/chapters/intro/running.html) for configuring, building, testing, and installing a project.
 
-```
+You can build Soufflé by typing:
+
+```sh
 cd souffle
-cmake -S . -B build
+cmake -S . -B build ## example of options: -DCMAKE_BUILD_TYPE=Release -DSOUFFLE_DOMAIN_64BIT=ON
 cmake --build build
 ```
 This may take up some time. However, this may be sped up with, for instance:
-```
+```sh
 cmake --build build -j8
 ```
 which will run `cmake` with 8 jobs at a time.
@@ -64,7 +97,7 @@ MAC OS X does not have OpenMP/C++ nor GNU Bison version 3.0.2 or higher installe
 
 We recommend [brew](http://brew.sh) to install the required tools for building Soufflé. Run the following commands prior to executing `cmake`:
 
-```
+```sh
 brew update
 brew install cmake bison libffi mcpp pkg-config
 brew reinstall gcc
@@ -73,31 +106,35 @@ brew link libffi --force
 export PKG_CONFIG_PATH=/usr/local/opt/libffi/lib/pkgconfig/
 ```
 
-Note: Be careful with the search path for bison, so it points to the correct one. By default, macOS includes bison 2.3 at `/usr/bin/bison`, however brew installs the newer version to `/usr/local/bin/bison`. This can be done by prepending this directory to the path, however, this can break other systems - `PATH=/usr/local/bin:$PATH`. Also note that the version of gcc installed may be different, so 'g++-8' may need to be changed.
+Note: Be careful with the search path for bison, so it points to the correct one. By default, macOS includes bison 2.3 at `/usr/bin/bison`, however brew installs the newer version to `/usr/local/bin/bison`. This can be done by prepending this directory to the path, however, this can break other systems - `PATH=/usr/local/bin:$PATH`. Also note that the version of gcc installed may be different, so `g++-8` may need to be changed.
 
 Soufflé is built by 
 
-```
+```sh
 cd souffle
 cmake -S . -B build
 cmake --build build
 ```
 This may take up some time. However, this may be sped up with, for instance:
-```
+```sh
 cmake --build build -j8
 ```
 which will run `cmake` with 8 jobs at a time.
 
-### Testing Soufflé
+### Windows & Visual Studio Build
 
-With 
-```
+See `.github/workfloww/VS-CI-Tests.yml` for an example of how to build and test on Windows with Visual Studio 2019 using package managers `Chocolatey` and `vcpkg` to resolve dependencies.
+
+## Testing Soufflé
+
+With:
+```sh
   cd build
   ctest
 ```
-numerous unit tests and regression tests are performed. This may take up to 45min.
+Numerous unit tests and regression tests are performed. This may take up to 45min.
 However, this may be sped up with, for instance:
-```
+```sh
 ctest -j8
 ```
 which will run 8 jobs at a time.
@@ -106,40 +143,30 @@ For more control, `-R <regex>` allows you to run tests that matches the regular 
 `-L <regex>` allows you to run tests with _labels_ matching the regular expression, use `--print-labels` to show all available labels;
 `--rerun-failed` allows you to run only the tests that failed previously.
 
+```sh
+cd build
+# run tests in interpreted mode (fast)
+ctest -L interpreted -VV --output-on-failure
+# run tests in compiled mode (slower)
+ctest -LE interpreted -VV --output-on-failure
+```
+
 For more options please type `ctest --help`.
 
-### Installing Soufflé
+## Installing Soufflé
 
 If you would like to install Soufflé in your system, specify an installation directory with `-DCMAKE_INSTALL_PREFIX=<install-dir>`. The executable, scripts, and header files will be stored in the directory ```<install-dir>```. Use an absolute path for ```<install-dir>```. Type 
-```
+```sh
  cd souffle
  cmake -S . -B build -DCMAKE_INSTALL_PREFIX=<install-dir>
  cmake --build build --target install
 ```
 to install Soufflé. By setting the path variable 
-```
+```sh
  PATH=$PATH:<install-dir>/bin
 ``` 
 the Soufflé commands ```souffle``` and ```souffleprof``` are available to the users.
 
-
-### Configuring Soufflé
-
-To specify build options, run `cmake -S . -B build -D<option>=<value>`. Alternatively, run `ccmake build` to start cmake with a terminal GUI interface that lets you configure the options.
-
-The most relevant options are listed below.
-
- - `SOUFFLE_DOMAIN_64BIT` Enable(=`ON`)/disable(=`OFF`) 64-bit number values in Datalog tuples; default is `OFF`, i.e., domain size is 32 bit.
- - `SOUFFLE_SANITISE_MEMORY` Enable(=`ON`)/disable(=`OFF`) memory sanitiser; default is `OFF`.
- - `SOUFFLE_SANITISE_THREAD` Enable(=`ON`)/disable(=`OFF`) thread sanitiser; default is `OFF`.
- - `SOUFFLE_SWIG` Enable(=`ON`)/disable(=`OFF`) SWIG language interface for various languages; default is `OFF`.
- - `SOUFFLE_SWIG_PYTHON` Enable(=`ON`)/disable(=`OFF`) Python SWIG interface; default is `OFF`.
- - `SOUFFLE_SWIG_JAVA` Enable(=`ON`)/disable(=`OFF`) Java SWIG interface; default is `OFF`.
- - `SOUFFLE_USE_CURSES`  Enable(=`ON`)/disable(=`OFF`) ncurses-based provenance display"; default is `ON`.
- - `SOUFFLE_USE_ZLIB` Enable(=`ON`)/disable(=`OFF`) use of libz file compression in I/O directives (i.e. `.input`/`.output`); default is `ON`.
- - `SOUFFLE_USE_SQLITE` Enable(=`ON`)/disable use of sqlite3 in I/O directives (i.e. `.input`/`.output`);  default is `ON`. 
-
-All available options can be found by browsing the source code, see `souffle/CMakeLists.txt`.
 
 ## IDE/Editor
 With CMake, you can easily integrate the Soufflé project with your IDE/editor.

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,5 @@
 # Souffle docs site
 
 This directory contains the text for Soufflé docs site, [www.souffle-lang.org](https://www.souffle-lang.org).
+
+To test locally: `bundle exec jekyll serve --watch` (requires `ruby` with `jekyll` and `webrick` gems).


### PR DESCRIPTION
Refresh the list of (optional) dependencies and cmake options.
Create the Windows build section, to be improved.