### PR TITLE
Add a missing subgoal in the "Sequences" example

### DIFF
--- a/pages/docs/examples.md
+++ b/pages/docs/examples.md
@@ -183,7 +183,7 @@ seq([l,s]) :- letter(l), seq(s), len(s,n), n<5.
 
 .decl len ( s : Seq, n:number )
 len(nil,0).
-len(s,n+1) :- seq(s), s = [l,r], len(r,n).
+len(s,n+1) :- seq(s), letter(l), s = [l,r], len(r,n).
 
 .decl res( s : symbol )
 .output res


### PR DESCRIPTION
Souffle will prompt an error when running the example code provided in section "Sequences using Recursive Records" in `examples.md`. 
```
Warning: Variable l only occurs once at line 14
len(s,n+1) :- seq(s), s = [l,r], len(r,n).
---------------------------^---------------
```
This PR added a `letter(l)` subgoal on the RHS of the rule.