### PR TITLE
Update examples.md to remove deprecated output qualifier warning

### DIFF
--- a/pages/docs/examples.md
+++ b/pages/docs/examples.md
@@ -43,7 +43,8 @@ ld("v4","v1","f").
 
 // -- analysis --
 
-.decl alias( a:var, b:var ) output
+.decl alias( a:var, b:var )
+.output alias
 alias(X,X) :- assign(X,_).
 alias(X,X) :- assign(_,X).
 alias(X,Y) :- assign(X,Y).
@@ -273,7 +274,8 @@ Frequently, components can be described in an abstract, generic way such that it
 NetA.edge("A","B").
 NetA.edge("B","C").
 
-.decl resA(a:symbol, b:symbol) output
+.decl resA(a:symbol, b:symbol)
+.output resA
 resA(X,Y) :- NetA.reach(X,Y).
 
 

--- a/pages/docs/examples.md
+++ b/pages/docs/examples.md
@@ -47,6 +47,11 @@ ld("v4","v1","f").
 .output alias
 alias(X,X) :- assign(X,_).
 alias(X,X) :- assign(_,X).
+alias(X,X) :- new(X,_).
+alias(X,X) :- ld(X,_,_).
+alias(X,X) :- ld(_,X,_).
+alias(X,X) :- st(X,_,_).
+alias(X,X) :- st(_,_,X).
 alias(X,Y) :- assign(X,Y).
 alias(X,Y) :- ld(X,A,F), alias(A,B), st(B,F,Y).
 


### PR DESCRIPTION
When I was following the documentation and run the example code, there were a warning say that the output qualifier has been deprecated, and I see the code in the end of this page, there has been the code without "output"qualifier, so I remove this qualifier and update the code in the examples.md.