### PR TITLE
arguments.md: to_number() bin+hex examples don't work on latest release of Souffle

### DIFF
--- a/pages/docs/arguments.md
+++ b/pages/docs/arguments.md
@@ -90,7 +90,7 @@ The output would be:
 123
 1534
 ```
-In souffle >2.4.1, or when building from source after [030e111b](https://github.com/souffle-lang/souffle/commit/030e111be9e3aa90033092e56ce49af96dd36790), functor **to_number(*string*)** will also recognise hex and binary strings with a prefix. 
+In souffle `>=2.5`, functor **to_number(*string*)** also recognises hex and binary strings with a prefix.
 ```prolog
 .decl tonumber(n:number)
 .output tonumber

--- a/pages/docs/arguments.md
+++ b/pages/docs/arguments.md
@@ -90,6 +90,18 @@ The output would be:
 123
 1534
 ```
+In souffle >2.4.1, or when building from source after [030e111b](https://github.com/souffle-lang/souffle/commit/030e111be9e3aa90033092e56ce49af96dd36790), functor **to_number(*string*)** will also recognise hex and binary strings with a prefix. 
+```prolog
+.decl tonumber(n:number)
+.output tonumber
+tonumber(n) :- n=to_number("0xff").
+tonumber(n) :- n=to_number("0b111").
+```
+The output would be:
+``` 
+255
+7
+```
 The reverse operation **to_string(*number*)** also exists, which turns a number to its string representation.
 
 Soufflé supports standard arithmetic operations **+**, **-**, **&#42;**, **&#47;**, **&#94;** and **&#37;**. Examples of this are given below.

--- a/pages/docs/arguments.md
+++ b/pages/docs/arguments.md
@@ -78,21 +78,17 @@ llo
 ld!
 ```
 
-Functor **to_number(*string*)** transforms a string representing a number to its associated number, it also recognises hex and binary numbers with a prefix.
+Functor **to_number(*string*)** transforms a string representing a number to its associated number.
 ```prolog
 .decl tonumber(n:number)
 .output tonumber
 tonumber(n) :- n=to_number("123").
 tonumber(n) :- n=to_number("1534").
-tonumber(n) :- n=to_number("0xff").
-tonumber(n) :- n=to_number("0b111").
 ```
 The output would be:
 ```
 123
 1534
-255
-7
 ```
 The reverse operation **to_string(*number*)** also exists, which turns a number to its string representation.
 


### PR DESCRIPTION
#140 was merged in November, to reflect the changes made to souffle in [030e111b](https://github.com/souffle-lang/souffle/commit/030e111be9e3aa90033092e56ce49af96dd36790) (PR \#2439 in that project). However, that commit missed the cut for souffle 2.4.1 by about one day. Moreover, the Ubuntu PPA described in the docs has 2.4 as its latest release. Right now, these two binary+hex examples only work if you build souffle from source, containing the `030e111b` changeset. 

On Souffle 2.4, you'll get 0 as the output of: 
```prolog
tonumber(n) :- n=to_number("0xff").
tonumber(n) :- n=to_number("0b111").
```

At the end of the day, this is a pretty minor nitpick, but I think the docs should note if some example doesn't work on the most recent release. I imagine many users trying Souffle out for the first time are probably installing from rpm/deb, not from source. 